### PR TITLE
Make record's Promise resolve with the stream

### DIFF
--- a/microm.js
+++ b/microm.js
@@ -184,6 +184,8 @@ class Microm {
       
     this.recordRTC = recordRTC;
     this.isRecording = true;
+
+    return stream;
   }
 
   onUserMediaError() {


### PR DESCRIPTION
As reported in https://github.com/zzarcon/microm/issues/24, there is no way to destroy the red icon. The only way to remove that is by stopping the stream.

Currently, the stream only resides inside the closure, and there is no way to access it.

The `record` method returns a Promise which is resolved with `undefined`, since the callback `startUserMedia` doesn't return any value. This PR aims to add the possibility to get the stream as soon as we start recording, so we can have a low-level access to the stream.