### PR TITLE
safari fix

### DIFF
--- a/microm.js
+++ b/microm.js
@@ -179,7 +179,7 @@ class Microm {
   }
 
   startUserMedia(stream) {
-    var recordRTC = RecordRTC(stream, {type: 'audio'})
+    var recordRTC = RecordRTC(stream, {type: 'audio', recorderType: RecordRTC.StereoAudioRecorder});
     recordRTC.startRecording();
       
     this.recordRTC = recordRTC;
@@ -188,8 +188,8 @@ class Microm {
     return stream;
   }
 
-  onUserMediaError() {
-    // TODO: Handle recording error
+  onUserMediaError(e) {
+    console.log(e);
   }
 
   /**


### PR DESCRIPTION
Got an error trying to record audio in Mobile Safari (iPhone 6, iOS 11): 
```
TypeError: GetRecorderType is not a constructor (evaluating 'new Recorder(mediaStream, config)'), 
stack: initRecorder startRecording startUserMedia startUserMedia@[native code] onInvoke run onInvokeTask runTask drainMicroTaskQueue promiseReactionJob@[native code]
```

This PR fixes this error